### PR TITLE
Workaround for windows-2022

### DIFF
--- a/pkg-check/action.yml
+++ b/pkg-check/action.yml
@@ -89,7 +89,7 @@ runs:
        if [ "${{ runner.os }}" = Linux ]; then
          PKGTYPE=source;
        else
-         BRPATH=$BLDIR/repo`Rscript -e 'cat(contrib.url("",.Platform$pkgType))'`
+         BRPATH=$BLDIR/repo`Rscript -e 'cat(contrib.url('\'\'',.Platform$pkgType))'`
          echo Binary install - target repo is $BRPATH
          mkdir -p $BRPATH
          echo '' > $BRPATH/PACKAGES


### PR DESCRIPTION
For some reason, on windows-2022 runners, this results in parse error (unexpected end of input):
BRPATH=$BLDIR/repo`Rscript -e 'cat(contrib.url("",.Platform$pkgType))'`

The suggested quoting happens to be working on those runners, while still valid and working on at least macOS and Ubuntu.